### PR TITLE
Update the documentation to reference SendRequestAsync()

### DIFF
--- a/Medidata.RWS.NET.Standard/Medidata.RWS.NET.Standard.csproj
+++ b/Medidata.RWS.NET.Standard/Medidata.RWS.NET.Standard.csproj
@@ -13,7 +13,7 @@
     <Title>RWS.NET</Title>
     <Description>RWS.NET is a comprehensive, fluent .NET Standard 2.0 API library for Medidata RAVE Web Services (RWS). It handles a large portion of the boilerplate C# code you'd normally have to write in order to communicate with RWS, allowing you to get up and running faster.</Description>
     <PackageId>RWS.NET</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Owners>Matthew Koch, MSKCC</Owners>
     <Copyright>Copyright 2018 Matthew Koch and Memorial Sloan Kettering Cancer Center</Copyright>
     <ReleaseVersion>1.0.1</ReleaseVersion>

--- a/Medidata.RWS.NET.Standard/docs/basic_requests.rst
+++ b/Medidata.RWS.NET.Standard/docs/basic_requests.rst
@@ -10,35 +10,17 @@ Returns the RWS version number. Specifically, this is the textual response retur
 
 .. code-block:: c#
 
-	using Medidata.RWS.NET.Standard.Core.Requests;
+    //Create a connection
+    var connection = new RwsConnection("innovate"); // no authentication required
 
-	//Create a connection
-	var connection = new RwsConnection("innovate"); // no authentication required
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new VersionRequest()) as RwsTextResponse;
 
-	//Send the request / get a response
-	var response = connection.SendRequest(new VersionRequest()) as RWSTextResponse;
+    //Write the response text to the console
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
-	//Write the response text to the console
-	Console.Write(response.ResponseText);
-	//1.15.0
+    //1.16.0
 
-BuildVersionRequest()
-=====================
-Returns the internal RWS build number. Specifically, this is the textual response returned when calling ``https://{ subdomain }.mdsol.com/RaveWebServices/version/build``.
-
-.. code-block:: c#
-
-	using Medidata.RWS.Core.Requests;
-
-	//Create a connection
-	var connection = new RwsConnection("innovate"); // no authentication required
-
-	//Send the request / get a response
-	var response = connection.SendRequest(new BuildVersionRequest()) as RWSTextResponse;
-
-	//Write the response text to the console
-	Console.Write(response.ResponseText);
-	//5.6.5.335
 
 TwoHundredRequest()
 ===================
@@ -47,35 +29,13 @@ Specifically, this is the html response returned when calling ``https://{ subdom
 
 .. code-block:: c#
 
-	using Medidata.RWS.NET.Standard.Core.Requests;
+    //Create a connection
+    var connection = new RwsConnection("innovate"); // no authentication required
 
-	//Create a connection
-	var connection = new RwsConnection("innovate"); // no authentication required
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new TwoHundredRequest()) as RwsTextResponse;
 
-	//Send the request / get a response
-	var response = connection.SendRequest(new TwoHundredRequest()) as RWSTextResponse;
+    //Write the response text to the console
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
-	//Write the response text to the console
-	Console.Write(response.ResponseText);
-	//<!DOCTYPE html>\r\n<html>\r\n<head><script..........
-
-
-CacheFlushRequest()
-===================
-Send a request to flush the RWS cache. Typically, this is used to immediately implement configuration changes in RWS.
-Under normal circumstances, this request is unnecessary as RAVE and RWS manage their own caching mechanisms automatically.
-Specifically, this is the equivalent of calling ``https://{ subdomain }.mdsol.com/RaveWebServices/webservice.aspx?CacheFlush``.
-
-.. code-block:: c#
-
-	using Medidata.RWS.Core.Requests;
-
-	//Create a connection
-	var connection = new RwsConnection("innovate", "username", "password"); // authentication is required
-
-	//Send the request / get a response
-	var response = connection.SendRequest(new CacheFlushRequest()) as RWSResponse;
-
-	//Write the response text to the console
-	Console.Write(response.IsTransactionSuccessful);
-	//true
+    //<!DOCTYPE html>\r\n<html>\r\n<head><script..........

--- a/Medidata.RWS.NET.Standard/docs/builders.rst
+++ b/Medidata.RWS.NET.Standard/docs/builders.rst
@@ -68,8 +68,13 @@ Using this ODM conformant XML, you could now POST it to RAVE by wrapping it in a
 
 .. code-block:: c#
 
-	RwsConnection conn = new RwsConnection("innovate", "username", "password");
-	var registrationRequest = new PostDataRequest(registrationXml);
-	var response = conn.SendRequest(registrationRequest) as RWSPostResponse;
 
-	//If successful, SUBJECT001 should be registered in SITE01 for the Mediflex study.
+    //Create a connection
+    var connection = new RwsConnection("innovate", "username", "password");
+
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new PostDataRequest(registrationXml)) as RwsPostResponse;
+
+    Console.Write(response.SubjectNumberInStudy); // 12345
+
+    //If successful, SUBJECT001 should be registered in SITE01 for the Mediflex study.

--- a/Medidata.RWS.NET.Standard/docs/core_resources.rst
+++ b/Medidata.RWS.NET.Standard/docs/core_resources.rst
@@ -22,8 +22,8 @@ Returns a list of EDC studies (as a ``RWSStudies`` object). Excludes studies tha
 	//Create a connection
 	var connection = new RwsConnection("innovate", "username", "password"); // authentication required
 
-	//Send the request / get a response
-	var response = connection.SendRequest(new ClinicalStudiesRequest()) as RWSStudies;
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new ClinicalStudiesRequest()) as RwsStudies;
 
 	//Write the study list to the console
 	foreach (var s in response)
@@ -78,8 +78,8 @@ Parameters
 	//Create a connection
 	var connection = new RwsConnection("innovate", "username", "password"); // authentication required
 
-	//Send the request / get a response
-	var response = connection.SendRequest(new StudySubjectsRequest("Mediflex", "Prod")) as RWSSubjects;
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new StudySubjectsRequest("Mediflex", "Prod")) as RwsSubjects;
 
 	//Write each subject key to the console
 	foreach (var s in response)
@@ -113,17 +113,16 @@ or, to filter the data by form:
 
 .. code-block:: c#
 
-	using Medidata.RWS.NET.Standard.Core.Requests
-	using Medidata.RWS.NET.Standard.Core.Requests.Datasets;
-
 	//Create a connection
 	var connection = new RwsConnection("innovate", "username", "password"); // authentication required
+    
 
-	//Send the request / get a response
-	var response = connection.SendRequest(new StudyDatasetRequest("Mediflex", "Prod", dataset_type: "regular")) as RWSResponse;
+    //Send the request / get a response
+    var response = await connection.SendRequestAsync(new StudyDatasetRequest("Mediflex", "Prod", dataset_type: "regular")) as RwsResponse;
+
 
 	//Write the XML response to the console (see XML below)
-	Console.Write(response.RawXMLString());
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
 
 .. code-block:: xml
@@ -191,13 +190,16 @@ or, to filter the data by form:
     //Create a connection
     var connection = new RwsConnection("innovate", "username", "password"); // authentication required
 
+
     //Send the request / get a response
-    var response = connection.SendRequest(new SubjectDatasetRequest("Mediflex", "Prod", subject_key: "1", dataset_type: "regular")) as RWSResponse;
+    var response = await connection.SendRequestAsync(new SubjectDatasetRequest("Mediflex", "Prod", subject_key: "1", dataset_type: "regular")) as RwsResponse;
+
 
     //Write the XML response to the console (see XML below)
-    Console.Write(response.RawXMLString());
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
 
+   
 .. code-block:: xml
 
     <?xml version="1.0" encoding="utf-8"?>
@@ -267,11 +269,14 @@ or, to filter the data by form:
     //Create a connection
     var connection = new RwsConnection("innovate", "username", "password"); // authentication required
 
+
     //Send the request / get a response
-    var response = connection.SendRequest(new VersionDatasetRequest(project_name: "Mediflex", environment_name: "Dev", version_oid: "999")) as RWSResponse;
+    var response = await connection.SendRequestAsync(new VersionDatasetRequest(project_name: "Mediflex", environment_name: "Dev", version_oid: "999")) as RwsResponse;
+
 
     //Write the XML response to the console (see XML below)
-    Console.Write(response.RawXMLString());
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
+
 
 *Note the **MetaDataVersionOID** value in the XML response.*
 

--- a/Medidata.RWS.NET.Standard/docs/getting_started.rst
+++ b/Medidata.RWS.NET.Standard/docs/getting_started.rst
@@ -37,20 +37,17 @@ The RAVE username and RAVE password parameters should reference a dedicated RAVE
 
 .. code-block:: c#
 
-	var response = connection.SendRequest(datasetRequest) as RWSResponse;
-
+	var response = await connection.SendRequestAsync(datasetRequest) as RwsResponse;
+    
 4. Dealing with the response/exception.
 
 .. code-block:: c#
 
-	Console.Write(response.RawXMLString());
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
 5. Putting this all together, we have the following.
 
 .. code-block:: c#
-
-	using Medidata.RWS.NET.Standard.Core.Requests.Datasets;
-	using Medidata.RWS.NET.Standard.Core.Requests;
 
 	//Create a connection
 	var connection = new RwsConnection("innovate", "RAVE username", "RAVE password");
@@ -59,10 +56,10 @@ The RAVE username and RAVE password parameters should reference a dedicated RAVE
 	var datasetRequest = new SubjectDatasetRequest("MediFlex", "PROD", subject_key: "SUBJECT001", formOid: "HEM");
 
 	//Send the request / get a response
-	var response = connection.SendRequest(datasetRequest) as RWSResponse;
+    var response = await connection.SendRequestAsync(datasetRequest) as RwsResponse;
 
 	//Write the response XML string to the console
-	Console.Write(response.RawXMLString());
+    Console.Write(await response.ResponseObject.Content.ReadAsStringAsync());
 
 The above steps outline how to retrieve data for **SUBJECT001**'s **HEM** form in the **MediFlex** study (specifically, the **PROD** environment).
 


### PR DESCRIPTION
Update the documentation to reference the SendRequestAsync() method (and await operator) instead of SendRequest().

Fixes #9 